### PR TITLE
docs: update backend url

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,19 @@ pnpm lint
 ## 🌐 URLs del Ecosistema
 
 - **Cliente Web**: http://localhost:3000
-- **Backend API**: http://localhost:3001
+- **Backend API (Railway)**: https://web-production-927f.up.railway.app
 - **Panel Admin**: http://localhost:5173
 - **App Móvil**: https://v0-jaguar-express-design.vercel.app/
 - **Prisma Studio**: http://localhost:5555
+
+> Para desarrollo local puedes usar `http://localhost:3001` o configurar la variable de entorno `NEXT_PUBLIC_API_URL` con la URL que necesites.
 
 ## 📝 Documentación Adicional
 
 - [📋 Documento de Requerimientos (PRD)](.trae/documents/jaguar-express-prd.md)
 - [🏗️ Arquitectura Técnica](.trae/documents/jaguar-express-arquitectura-tecnica.md)
-- [🔗 API Documentation](http://localhost:3001/docs) (cuando el servidor esté ejecutándose)
+- [🔗 API Documentation](https://web-production-927f.up.railway.app/docs) (servidor en Railway)
+- [🔗 API Documentation (local)](http://localhost:3001/docs)
 
 ## 🤝 Contribución
 

--- a/jaguar-express/next.config.js
+++ b/jaguar-express/next.config.js
@@ -12,6 +12,8 @@ const nextConfig = {
     formats: ['image/webp', 'image/avif'],
   },
   env: {
+    // Cambia esta URL mediante NEXT_PUBLIC_API_URL para apuntar al backend en producción.
+    // Ejemplo de Railway: https://web-production-927f.up.railway.app
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
     NEXT_PUBLIC_APP_NAME: 'Jaguar Express',
     NEXT_PUBLIC_APP_VERSION: '1.0.0',

--- a/jaguar-express/src/lib/api.ts
+++ b/jaguar-express/src/lib/api.ts
@@ -15,6 +15,8 @@ import {
 } from '@/types';
 
 // Configuración base de la API
+// Para producción define NEXT_PUBLIC_API_URL con la URL del backend (ej. Railway:
+// https://web-production-927f.up.railway.app); en desarrollo usa http://localhost:3001.
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 // Crear instancia de axios


### PR DESCRIPTION
## Summary
- document Railway backend URL
- clarify API base URL configuration for local and production

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file in jaguar-express-admin)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ffdd49588320b8c4f639e362e28e